### PR TITLE
Use the daemon for state and config key/value functions

### DIFF
--- a/cto_ai/daemon_request.py
+++ b/cto_ai/daemon_request.py
@@ -25,7 +25,24 @@ start_progress = _make_requester("progress-bar/start")
 advance_progress = _make_requester("progress-bar/advance")
 stop_progress = _make_requester("progress-bar/stop")
 track = _make_requester("track")
+set_state = _make_requester("state/set")
+set_config = _make_requester("config/set")
 
+def _make_sync_requester(endpoint):
+    def requester(body):
+        response = requests.post(f"http://127.0.0.1:{_port()}/{endpoint}", json=body)
+
+        response.raise_for_status()
+        response_data = response.json()
+
+        return response_data["value"]
+
+    return requester
+
+get_state = _make_sync_requester("state/get")
+get_all_state = _make_sync_requester("state/get-all")
+get_config = _make_sync_requester("config/get")
+get_all_config = _make_sync_requester("config/get-all")
 
 def _make_async_requester(endpoint):
     def requester(body):

--- a/cto_ai/sdk.py
+++ b/cto_ai/sdk.py
@@ -36,6 +36,9 @@ class JsonStore:
         self.getter_all = getter_all
         self.setter = setter
 
+    def get_all(self):
+        return self.getter_all()
+
     def get(self, key: str):
         return self.getter({"key": key})
 

--- a/cto_ai/sdk.py
+++ b/cto_ai/sdk.py
@@ -31,30 +31,21 @@ def get_config_path() -> str:
 
 
 class JsonStore:
-    def __init__(self, filename: str):
-        self.filename = filename
-
-    def get_all(self):
-        try:
-            with open(self.filename) as infile:
-                return json.load(infile)
-        except (json.JSONDecodeError, OSError):
-            return {}
+    def __init__(self, getter, getter_all, setter):
+        self.getter = getter
+        self.getter_all = getter_all
+        self.setter = setter
 
     def get(self, key: str):
-        return self.get_all().get(key)
+        return self.getter({"key": key})
 
     def set(self, key: str, value: str):
-        state = self.get_all()
-        state[key] = value
-
-        with open(self.filename, "w") as outfile:
-            json.dump(state, outfile)
-        return state
+        self.setter({"key": key, "value": value})
+        return self.getter_all()
 
 
-state = JsonStore(os.path.join(get_state_path(), "state.json"))
-config = JsonStore(os.path.join(get_config_path(), "config.json"))
+state = JsonStore(daemon_request.get_state, daemon_request.get_all_state, daemon_request.set_state)
+config = JsonStore(daemon_request.get_config, daemon_request.get_all_config, daemon_request.set_config)
 
 
 def track(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cto-ai",
-    version="1.0.0b1",
+    version="2.0.0",
     author="Danielle Brook-Roberge",
     author_email="danielle@cto.ai",
     description="SDK for The Ops Platform",


### PR DESCRIPTION
This MR replaces the pure-Python state and config implementations with ones that call into the SDK daemon (must be version 2.1.0 or higher). It also adds `sdk.state.get_all` and `sdk.config.get_all` functions that get all keys and values from the respective stores.

This adds flexibility as needed for future features involving state and config.