### PR TITLE
Make the default arg for checkbox optional

### DIFF
--- a/cto_ai/prompt.py
+++ b/cto_ai/prompt.py
@@ -75,7 +75,7 @@ def checkbox(
     message: str,
     *,
     choices: Iterable[str],
-    default: Optional[Iterable[Union[str, int]]],
+    default: Optional[Iterable[Union[str, int]]] = None,
     flag: Optional[str] = None,
 ):
     """Prompt the user for a selection of any number members of a list of strings"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cto-ai",
-    version="2.0.0",
+    version="2.0.1",
     author="Danielle Brook-Roberge",
     author_email="danielle@cto.ai",
     description="SDK for The Ops Platform",


### PR DESCRIPTION
As an oversight, the `default` argument of `prompt.checkbox` was left as mandatory. This MR makes it optional.